### PR TITLE
Code review feedback for cmake-debugging

### DIFF
--- a/include/vcpkg/fwd/vcpkgcmdarguments.h
+++ b/include/vcpkg/fwd/vcpkgcmdarguments.h
@@ -11,4 +11,5 @@ namespace vcpkg
     struct HelpTableFormatter;
     struct VcpkgCmdArguments;
     struct FeatureFlagSettings;
+    struct PortApplicableSetting;
 }

--- a/include/vcpkg/vcpkgcmdarguments.h
+++ b/include/vcpkg/vcpkgcmdarguments.h
@@ -80,6 +80,21 @@ namespace vcpkg
         bool dependency_graph;
     };
 
+    struct PortApplicableSetting
+    {
+        std::string value;
+
+        PortApplicableSetting(StringView setting);
+        PortApplicableSetting(const PortApplicableSetting&);
+        PortApplicableSetting(PortApplicableSetting&&);
+        PortApplicableSetting& operator=(const PortApplicableSetting&);
+        PortApplicableSetting& operator=(PortApplicableSetting&&);
+        bool is_port_affected(StringView port_name) const noexcept;
+
+    private:
+        std::vector<std::string> affected_ports;
+    };
+
     struct VcpkgCmdArguments
     {
         static VcpkgCmdArguments create_from_command_line(const ILineReader& fs,
@@ -161,13 +176,13 @@ namespace vcpkg
         constexpr static StringLiteral GITHUB_REPOSITORY_OWNER_ID = "GITHUB_REPOSITORY_OWNER_ID";
         Optional<std::string> github_repository_owner_id;
 
+        constexpr static StringLiteral CMAKE_DEBUGGING_ARG = "cmake-debug";
+        Optional<PortApplicableSetting> cmake_debug;
+        constexpr static StringLiteral CMAKE_CONFIGURE_DEBUGGING_ARG = "cmake-configure-debug";
+        Optional<PortApplicableSetting> cmake_configure_debug;
+
         constexpr static StringLiteral CMAKE_SCRIPT_ARG = "cmake-args";
         std::vector<std::string> cmake_args;
-
-        constexpr static StringLiteral CMAKE_DEBUGGING_ARG = "cmake-debug";
-        std::vector<std::string> cmake_debug;
-        constexpr static StringLiteral CMAKE_CONFIGURE_DEBUGGING_ARG = "cmake-configure-debug";
-        std::vector<std::string> cmake_configure_debug;
 
         constexpr static StringLiteral EXACT_ABI_TOOLS_VERSIONS_SWITCH = "abi-tools-use-exact-versions";
         Optional<bool> exact_abi_tools_versions;

--- a/src/vcpkg-test/arguments.cpp
+++ b/src/vcpkg-test/arguments.cpp
@@ -160,3 +160,22 @@ TEST_CASE ("Feature flag off", "[arguments]")
     auto v = VcpkgCmdArguments::create_from_arg_sequence(t.data(), t.data() + t.size());
     CHECK(!v.versions_enabled());
 }
+
+TEST_CASE ("CMake debugger flags", "[arguments]")
+{
+    std::vector<std::string> t = {
+        "--x-cmake-debug", "\\\\.\\pipe\\tespipe;zlib;bar;baz", "--x-cmake-configure-debug", "\\\\.\\pipe\\configure-pipe"};
+    auto v = VcpkgCmdArguments::create_from_arg_sequence(t.data(), t.data() + t.size());
+    auto& cmake_debug = v.cmake_debug.value_or_exit(VCPKG_LINE_INFO);
+    REQUIRE(cmake_debug.value == "\\\\.\\pipe\\tespipe");
+    REQUIRE(!cmake_debug.is_port_affected("7zip"));
+    REQUIRE(cmake_debug.is_port_affected("zlib"));
+    REQUIRE(cmake_debug.is_port_affected("bar"));
+    REQUIRE(cmake_debug.is_port_affected("baz"));
+    REQUIRE(!cmake_debug.is_port_affected("bazz"));
+
+    auto& cmake_configure_debug = v.cmake_configure_debug.value_or_exit(VCPKG_LINE_INFO);
+    REQUIRE(cmake_configure_debug.value == "\\\\.\\pipe\\configure-pipe");
+    REQUIRE(cmake_configure_debug.is_port_affected("7zip"));
+    REQUIRE(cmake_configure_debug.is_port_affected("zlib"));
+}

--- a/src/vcpkg-test/arguments.cpp
+++ b/src/vcpkg-test/arguments.cpp
@@ -163,8 +163,10 @@ TEST_CASE ("Feature flag off", "[arguments]")
 
 TEST_CASE ("CMake debugger flags", "[arguments]")
 {
-    std::vector<std::string> t = {
-        "--x-cmake-debug", "\\\\.\\pipe\\tespipe;zlib;bar;baz", "--x-cmake-configure-debug", "\\\\.\\pipe\\configure-pipe"};
+    std::vector<std::string> t = {"--x-cmake-debug",
+                                  "\\\\.\\pipe\\tespipe;zlib;bar;baz",
+                                  "--x-cmake-configure-debug",
+                                  "\\\\.\\pipe\\configure-pipe"};
     auto v = VcpkgCmdArguments::create_from_arg_sequence(t.data(), t.data() + t.size());
     auto& cmake_debug = v.cmake_debug.value_or_exit(VCPKG_LINE_INFO);
     REQUIRE(cmake_debug.value == "\\\\.\\pipe\\tespipe");

--- a/src/vcpkg/commands.build.cpp
+++ b/src/vcpkg/commands.build.cpp
@@ -37,8 +37,6 @@
 #include <vcpkg/vcpkglib.h>
 #include <vcpkg/vcpkgpaths.h>
 
-#include <algorithm>
-
 using namespace vcpkg;
 
 namespace
@@ -780,26 +778,21 @@ namespace vcpkg
             variables.emplace_back("ARIA2", paths.get_tool_exe(Tools::ARIA2, stdout_sink));
         }
 
-        if (!args.cmake_debug.empty())
+        if (auto cmake_debug = args.cmake_debug.get())
         {
-            if (args.cmake_debug.size() == 1 ||
-                std::find(args.cmake_debug.begin(), args.cmake_debug.end(), scf.core_paragraph->name) !=
-                    args.cmake_debug.end())
+            if (cmake_debug->is_port_affected(scf.core_paragraph->name))
             {
                 variables.emplace_back("--debugger");
-                variables.emplace_back(fmt::format("--debugger-pipe={}", *args.cmake_debug.begin()));
+                variables.emplace_back(fmt::format("--debugger-pipe={}", cmake_debug->value));
             }
         }
 
-        if (!args.cmake_configure_debug.empty())
+        if (auto cmake_configure_debug = args.cmake_configure_debug.get())
         {
-            if (args.cmake_configure_debug.size() == 1 ||
-                std::find(args.cmake_configure_debug.begin(),
-                          args.cmake_configure_debug.end(),
-                          scf.core_paragraph->name) != args.cmake_configure_debug.end())
+            if (cmake_configure_debug->is_port_affected(scf.core_paragraph->name))
             {
                 variables.emplace_back(fmt::format("-DVCPKG_CMAKE_CONFIGURE_OPTIONS=--debugger;--debugger-pipe={}",
-                                                   *args.cmake_configure_debug.begin()));
+                                                   cmake_configure_debug->value));
             }
         }
 


### PR DESCRIPTION
* Make multiple uses of the new switches an error
* Deduplicate the logic of "no entries means no filter, one or more entries means port filter"
* Add unit test